### PR TITLE
Refactor module loading: Use require instead of hardcoded dofile path

### DIFF
--- a/CCLinkIE_TSN_Rev03.lua
+++ b/CCLinkIE_TSN_Rev03.lua
@@ -28,7 +28,7 @@ local CCIETSN_SDCRC_SZ			= 4
 local CCIETSN_HEADER_DATA_SZ	= 6
 local CCIETSN_HEADER_TEST		= 14
 
-dofile(DATA_DIR.."/plugins/SLMP_com_Rev03.lua")	-- [SLMP_com.lua] Directory path
+require("SLMP_com_Rev03")	-- [SLMP_com.lua] Directory path
 
 function bitval(num, d)
 	local mask = bit.lshift(0x1, d)
@@ -1436,3 +1436,4 @@ function Disp_myPortFilterStatus_help(buffer, tree, portnum)
 			unused1, portnum+1, unused1))
 
 end
+

--- a/SLMP_Rev03.lua
+++ b/SLMP_Rev03.lua
@@ -65,12 +65,12 @@ local protocol_port_names = {
 }
 
 if(cmddata_analyze) then
-	dofile(DATA_DIR.."/plugins/SLMP_com_Rev03.lua")	-- [SLMP_com.lua] Directory path
+	require("SLMP_com_Rev03")	-- [SLMP_com.lua] Directory path
 end
 
 -- First try to load the MELSEC helper module
 local melsec_helper_loaded = pcall(function() 
-    dofile(DATA_DIR.."/plugins/melsec_helper.lua")
+    require("melsec_helper")
 end)
 
 -- Create a fallback if melsec_helper.lua couldn't be loaded
@@ -413,4 +413,5 @@ slm_proto.prefs.detailed_melsec = Pref.bool("Detailed MELSEC Analysis", true,
     "Whether to show detailed analysis for MELSEC packets")
 slm_proto.prefs.detailed_slmp = Pref.bool("Detailed SLMP Analysis", true,
     "Whether to show detailed analysis for SLMP packets")
+
 


### PR DESCRIPTION
**Description** This PR modifies CCLinkIE_TSN_Rev03.lua to load the dependency SLMP_com_Rev03.lua using the standard Lua require function, replacing the previous dofile method that relied on a hardcoded absolute path.

**Reason for Change** The original code used dofile(DATA_DIR.."/plugins/SLMP_com_Rev03.lua"). This approach is brittle because it assumes the plugin is always located strictly within the global plugins directory. This causes errors if the user installs the script in a personal plugin folder or a different directory structure.

By switching to require("SLMP_com_Rev03"), we leverage Wireshark's built-in Lua package search path. This ensures the dependency is loaded correctly regardless of the specific installation path, making the plugin more portable and robust.

**Verification** I have tested this change locally. The plugin now loads without errors and the functionality works as expected.